### PR TITLE
Add missing "Exposing"

### DIFF
--- a/_posts/2016-09-17-porque-elm.md
+++ b/_posts/2016-09-17-porque-elm.md
@@ -347,7 +347,7 @@ Isso no final das contas é uma tag `p`, sem nenhum atributo e tem um nó de tex
 
 ```haskell
 import Html exposing (p, text)
-import Html.Attributes (class)
+import Html.Attributes exposing (class)
 
 p [ class "alert" ] [ text "Ahoy" ]
 ```
@@ -356,7 +356,7 @@ Agora esse código recebeu uma lista não-vazia de argumentos, logo equivale a `
 
 ```haskell
 import Html exposing (p, strong, text)
-import Html.Attributes (class)
+import Html.Attributes exposing (class)
 
 p
     [ class "alert" ]


### PR DESCRIPTION
fixes 

```
import Html.Attributes (class)
^ I am looking for one of the following things:     reserved word `as`     reserved word `exposing`     whitespace
```
